### PR TITLE
Allow loggers to use warn as well as warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,7 +95,12 @@ function buildFetch(behavior) {
   }
 
   function handleError(url, cacheKey, res, content, resolvedCallback) {
-    logger.warning("HTTP Fetching error %d for: %j", res.statusCode, url);
+    if (typeof logger.warning === "function") {
+      logger.warning("HTTP Fetching error %d for: %j", res.statusCode, url);
+    } else if (typeof logger.warn === "function") {
+      logger.warn("HTTP Fetching error %d for: %j", res.statusCode, url);
+    }
+
     let errorAge = -1;
 
     if (onError) {


### PR DESCRIPTION
Pino's warning level function is named `warn` - not `warning` - resulting in a TypeError being thrown when logging http errors. Can probably be solved in other ways as well, open to suggestions.