### PR TITLE
Pass original error and add url on timeout error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+# 5.4.0
+
+* Pass the original error as cause when a timeout occurs
+* Add the url that triggers a timeout in the timeout error message
+
 # 5.3.1
 
 Add _got_ `hooks` to behaviour

--- a/index.js
+++ b/index.js
@@ -221,7 +221,7 @@ function buildFetch(behavior) {
             return handleError(url, cacheKey, err.response, err.response.body, resolvedCallback);
           }
         } else if (err instanceof got.TimeoutError) {
-          return resolvedCallback(new VError("ESOCKETTIMEDOUT"));
+          return resolvedCallback(new VError(err, "%s yielded timeout", url));
         }
 
         return resolvedCallback(err);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exp-fetch",
-  "version": "5.3.1",
+  "version": "5.4.0",
   "description": "A small pluggable fetch lib",
   "main": "index.js",
   "scripts": {

--- a/test/fetchingTest.js
+++ b/test/fetchingTest.js
@@ -620,7 +620,7 @@ describe("fetch", () => {
 
       fetch(host + path, (err) => {
         if (!err) return done(new Error("No timeout"));
-        expect(err.message).to.include("ESOCKETTIMEDOUT");
+        expect(err.jse_cause.code).to.equal("ETIMEDOUT");
         done();
       });
     });
@@ -635,7 +635,7 @@ describe("fetch", () => {
 
       fetch(host + path, (err) => {
         if (!err) return done(new Error("No socket timeout"));
-        expect(err.message).to.include("ESOCKETTIMEDOUT");
+        expect(err.jse_cause.code).to.equal("ETIMEDOUT");
         done();
       });
     });
@@ -655,7 +655,7 @@ describe("fetch", () => {
 
       fetch(host + path, (err) => {
         if (!err) return done(new Error("No response timeout"));
-        expect(err.message).to.include("ESOCKETTIMEDOUT");
+        expect(err.jse_cause.code).to.equal("ETIMEDOUT");
         done();
       });
     });
@@ -669,7 +669,7 @@ describe("fetch", () => {
 
       fetch({ url: host + path, timeout: 1 }, (err) => {
         if (!err) return done(new Error("No timeout"));
-        expect(err.message).to.include("ESOCKETTIMEDOUT");
+        expect(err.jse_cause.code).to.equal("ETIMEDOUT");
         done();
       });
     });
@@ -686,7 +686,7 @@ describe("fetch", () => {
         timeout: { socket: 10 },
       }, (err) => {
         if (!err) return done(new Error("No timeout"));
-        expect(err.message).to.include("ESOCKETTIMEDOUT");
+        expect(err.jse_cause.code).to.equal("ETIMEDOUT");
         done();
       });
     });
@@ -701,9 +701,10 @@ describe("fetch", () => {
         .get("/someotherpath")
         .delay(30)
         .reply(200, { some: "content" });
+
       fetch({ url: host + path, timeout: 1 }, (err) => {
         if (!err) return done(new Error("No timeout"));
-        expect(err.message).to.include("ESOCKETTIMEDOUT");
+        expect(err.jse_cause.code).to.equal("ETIMEDOUT");
         done();
       });
     });
@@ -714,9 +715,23 @@ describe("fetch", () => {
         .get(path)
         .delay(30)
         .reply(200, { some: "content" });
+
       fetch({ url: host + path, timeout: 1 }).catch((err) => {
         if (!err) return done(new Error("No timeout"));
-        expect(err.message).to.include("ESOCKETTIMEDOUT");
+        expect(err.jse_cause.code).to.equal("ETIMEDOUT");
+        done();
+      });
+    });
+
+    it("should include the url that triggers timeout in the error", (done) => {
+      const fetch = fetchBuilder().fetch;
+      fake
+        .get(path)
+        .reply(200);
+
+      fetch({ url: host + path, timeout: 1 }, (err) => {
+        if (!err) return done(new Error("No timeout"));
+        expect(err.message).to.contain(`${host}${path} yielded timeout`);
         done();
       });
     });


### PR DESCRIPTION
Changes the error message of timeout errors to include the url triggering the timeout. Also adds the original got-error as the cause when throwing a timeout error. 

In addition, the error message no longer mentions `ESOCKETTIMEDOUT`. I changed this because I think it's misleading, considering that got no longer seems to have that specific error code anywhere (did it ever? Seems likely that it might be a leftover from when we used the `request` library). In order to find out where in the request process the timeout occured the got error includes a `timings` property that reveals this.

The change of error message is potentially breaking for code that acts on the error message, but I could only see a handful of instances where this is the case. However, the most important thing to me is that the url that timeouts is revealed in the error somehow. I'm open to discussing the other changes.