### PR TITLE
Catch option errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Changelog
 
 # Unreleased
 
+* Catch and forward internal errors to callback or return as rejected promise
 * Bump node from 14 to 16
 * Bump eslint from 8.3.0 to 8.26.0
 * Bump eslint-config-exp from 0.2.0 to 0.5.0 and obey the new linting rules


### PR DESCRIPTION
Any error should be handled by callback or returned as rejected promise

Before:

```js
try {
  fetch(invalidOption)
    .then(...)
    .catch(handleRequestError) 
} catch (error) {
  handleInvalidOptionError(error)
}

// or

try {
  fetch(invalidOption, (error) => {
    if (error) return handleRequestError(error);
    ...
  });
} catch(error) {
  handleInvalidOptionError(error);
}
```

Now: 

```js
fetch(invalidOption)
  .then(...)
  .catch(handleAnyError) 

// or

fetch(invalidOption, (error) => {
  if (error) return handleAnyError(error);
  ...
});
```