### PR TITLE
5.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+# 5.4.2
+* Ignore .DS_Store and document fetch retry and timeout config in README.
+* Bump deps to fix security audit.
+
 # 5.4.1
 
 * Bump deps to fix security audit.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "exp-fetch",
-  "version": "5.4.0",
+  "version": "5.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "exp-fetch",
-      "version": "5.4.0",
+      "version": "5.4.2",
       "license": "MIT",
       "dependencies": {
         "clone": "^2.1.1",
@@ -14,7 +14,7 @@
         "got": "^11.8.6",
         "lru-cache": "^6.0.0",
         "verror": "^1.10.1",
-        "xml2js": "^0.4.22"
+        "xml2js": "^0.5.0"
       },
       "devDependencies": {
         "chai": "^4.3.6",
@@ -3160,9 +3160,9 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
       "dependencies": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"
@@ -5509,9 +5509,9 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
       "requires": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exp-fetch",
-  "version": "5.4.1",
+  "version": "5.4.2",
   "description": "A small pluggable fetch lib",
   "main": "index.js",
   "scripts": {
@@ -34,7 +34,7 @@
     "got": "^11.8.6",
     "lru-cache": "^6.0.0",
     "verror": "^1.10.1",
-    "xml2js": "^0.4.22"
+    "xml2js": "^0.5.0"
   },
   "files": [
     "lib/",


### PR DESCRIPTION
This PR includes some improvements and fixes to the exp-fetch library.

The following changes were made in this commit:

- Updated the dependencies to fix a security issue.
- Added a configuration option to ignore .DS_Store files.
- Documented the fetch retry and timeout configuration in the README.
- Upgraded the xml2js dependency to version 0.5.0.

The package version has also been updated from 5.4.1 to 5.4.2 to reflect these changes.

To use the updated version of exp-fetch, simply update your package.json file to include the new version number, or run npm install exp-fetch@5.4.2 to install it directly.